### PR TITLE
Bump the version of architectury-loom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    dependencies {
-        classpath 'org.ow2.asm:asm:9.2'
-        classpath 'org.ow2.asm:asm-commons:9.2'
-        classpath 'org.ow2.asm:asm-tree:9.2'
-        classpath 'org.ow2.asm:asm-util:9.2'
-    }
-}
-
 plugins {
     id 'maven-publish'
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,7 +1,7 @@
 import net.fabricmc.loom.task.RemapJarTask
 
 plugins {
-    id 'dev.architectury.loom' version '1.0-SNAPSHOT'
+    id 'dev.architectury.loom' version '1.1-SNAPSHOT'
     //id 'com.matthewprenger.cursegradle' version '1.4.0'
     id 'com.github.johnrengelman.shadow' version '7.0.0'
 }


### PR DESCRIPTION
When running './gradlew build' on a clean environment, an exception 'Unsupported class file major version 63' occurs.

To fix this, we need to bump the version of the gradle plugin 'dev.architectury.loom' to '1.1-SNAPSHOT' as provided in 'https://github.com/architectury/architectury-templates/releases/download/release_build_1681557561530/1.19.4-forge.zip'.

 Once the architectury-loom version has been bumped, the old fix (by special asm version) can be safely removed.