### PR TITLE
 Real-time Development with ModernUI-Core

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     modCompileOnlyApi "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
     modCompileOnlyApi "mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"
 
-    if(rootProject.file('../ModernUI').exists()) {
+    if (rootProject.file('../ModernUI').exists()) {
         implementation(forgeDependencies("icyllis.modernui:ModernUI-Core"))
         shadow("icyllis.modernui:ModernUI-Core") {
             transitive = false

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -45,7 +45,6 @@ repositories {
             includeGroup 'org.parchmentmc.data'
         }
     }
-    mavenLocal()
     maven {
         url 'https://maven.izzel.io/releases/'
     }
@@ -67,13 +66,24 @@ dependencies {
     modCompileOnlyApi "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
     modCompileOnlyApi "mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"
 
-    implementation(forgeDependencies("icyllis.modernui:ModernUI-Core:${core_version}"))
-    shadow("icyllis.modernui:ModernUI-Core:${core_version}") {
-        transitive = false
-    }
-    implementation(forgeDependencies("icyllis.modernui:ModernUI-ViewPager:1.0.0"))
-    shadow("icyllis.modernui:ModernUI-ViewPager:1.0.0") {
-        transitive = false
+    if(rootProject.file('../ModernUI').exists()) {
+        implementation(forgeDependencies("icyllis.modernui:ModernUI-Core"))
+        shadow("icyllis.modernui:ModernUI-Core") {
+            transitive = false
+        }
+        implementation(forgeDependencies("icyllis.modernui:ModernUI-ViewPager"))
+        shadow("icyllis.modernui:ModernUI-ViewPager") {
+            transitive = false
+        }
+    } else {
+        implementation(forgeDependencies("icyllis.modernui:ModernUI-Core:${core_version}"))
+        shadow("icyllis.modernui:ModernUI-Core:${core_version}") {
+            transitive = false
+        }
+        implementation(forgeDependencies("icyllis.modernui:ModernUI-ViewPager:1.0.0"))
+        shadow("icyllis.modernui:ModernUI-ViewPager:1.0.0") {
+            transitive = false
+        }
     }
 
     implementation 'org.openjdk.jmh:jmh-core:1.35'

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ pluginManagement {
 
 rootProject.name = 'ModernUI-MC'
 
-if(file('../ModernUI').exists()) {
+if (file('../ModernUI').exists()) {
     includeBuild '../ModernUI'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,5 +15,9 @@ pluginManagement {
 
 rootProject.name = 'ModernUI-MC'
 
+if(file('../ModernUI').exists()) {
+    includeBuild '../ModernUI'
+}
+
 include 'forge'
 project(':forge').name = "ModernUI-Forge"


### PR DESCRIPTION
For enhance the collaboration and integration between ModernUI.
If use includeBuild to include ModernUI-Core, will show effect realtime in this project.
To make this change effect, you need clone ModernUI in same directory, as spigot build step.